### PR TITLE
ping_on_recompile extracts and sends the chapter_id too

### DIFF
--- a/vault/bin/ping_on_recompile
+++ b/vault/bin/ping_on_recompile
@@ -10,5 +10,12 @@ else
 fi 
 
 path=$(pwd | rev | cut -d'/' -f1-3 | rev)
-ping="$server/sku/recompiled?path=$path"
+cid=$(grep -oP 'chapterId="\K[^"]*' source.xml)
+
+if [ -z "$cid" ] ; then 
+  ping="$server/sku/recompiled?path=$path"
+else 
+  ping="$server/sku/recompiled?path=$path&c=$cid"
+fi 
+
 curl $ping


### PR DESCRIPTION
Quill is misbehaving. Hence, bash must take over